### PR TITLE
Refactor tracing setup and service init

### DIFF
--- a/src/bin/grpc_server.rs
+++ b/src/bin/grpc_server.rs
@@ -9,6 +9,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
 
     let config = config::load_config()?;
+    config::init_tracing(&config.log_level);
     let db = db::establish_connection(&config.db_url).await.map_err(|e| {
         error!("DB connection failed: {}", e);
         e

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,17 @@ fn validate_log_level(level: &str) -> Result<(), ValidationError> {
     }
 }
 
+/// Initializes tracing using the provided log level as the default filter
+pub fn init_tracing(level: &str) {
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let default_directive = format!("stateset_api={},tower_http=debug", level);
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(default_directive));
+
+    let _ = fmt().with_env_filter(filter).try_init();
+}
+
 /// Loads application configuration
 ///
 /// Layers configuration sources in this order:
@@ -142,9 +153,6 @@ fn validate_log_level(level: &str) -> Result<(), ValidationError> {
 /// 3. Docker config (config/docker.toml) if DOCKER env var is set
 /// 4. Environment variables (APP_*)
 pub fn load_config() -> Result<AppConfig, AppConfigError> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
 
     let run_env = env::var("RUN_ENV").unwrap_or_else(|_| DEFAULT_ENV.to_string());
     info!("Loading configuration for environment: {}", run_env);

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,13 @@ use crate::services::{
 };
 use crate::events::EventSender;
 
+// Macro for constructing services with shared resources
+macro_rules! init_service {
+    ($svc:ident, $db:expr, $sender:expr) => {
+        $svc::new($db.clone(), $sender.clone())
+    };
+}
+
 /// Services layer that encapsulates business logic
 #[derive(Debug, Clone)]
 pub struct AppServices {
@@ -49,12 +56,12 @@ pub struct AppServices {
 impl AppServices {
     pub fn new(db_pool: Arc<DatabaseConnection>, event_sender: Arc<EventSender>) -> Self {
         Self {
-            work_orders: WorkOrderService::new(db_pool.clone(), event_sender.clone()),
-            orders: OrderService::new(db_pool.clone(), event_sender.clone()),
-            inventory: InventoryService::new(db_pool.clone(), event_sender.clone()),
-            returns: ReturnService::new(db_pool.clone(), event_sender.clone()),
-            shipments: ShipmentService::new(db_pool.clone(), event_sender.clone()),
-            warranties: WarrantyService::new(db_pool.clone(), event_sender.clone()),
+            work_orders: init_service!(WorkOrderService, db_pool, event_sender),
+            orders: init_service!(OrderService, db_pool, event_sender),
+            inventory: init_service!(InventoryService, db_pool, event_sender),
+            returns: init_service!(ReturnService, db_pool, event_sender),
+            shipments: init_service!(ShipmentService, db_pool, event_sender),
+            warranties: init_service!(WarrantyService, db_pool, event_sender),
         }
     }
 }
@@ -74,19 +81,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load environment variables from .env file
     dotenv().ok();
     
-    // Initialize tracing with more structured configuration
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            // Use RUST_LOG environment variable, or default to info for our code and warn for others
-            std::env::var("RUST_LOG")
-                .unwrap_or_else(|_| "stateset_api=info,tower_http=debug,info".into())
-        )
-        .init();
-    
-    info!("Stateset API starting...");
-    
     // Load configuration from environment variables
     let config = config::load_config()?;
+
+    // Initialize tracing using configuration
+    config::init_tracing(&config.log_level);
+
+    info!("Stateset API starting...");
     
     // Connect to the database
     info!("Connecting to database...");


### PR DESCRIPTION
## Summary
- centralize service initialization via `init_service` macro
- move tracing initialization to reusable `init_tracing` function
- call `init_tracing` from the main and gRPC binaries

## Testing
- `cargo test -q` *(fails: failed to download from crates.io)*