### PR TITLE
Expand command modules with warehouse and carrier support

### DIFF
--- a/src/commands/carriers/create_carrier_command.rs
+++ b/src/commands/carriers/create_carrier_command.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct CreateCarrierCommand {
+    #[validate(length(min = 1))]
+    pub name: String,
+    pub tracking_url: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateCarrierResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for CreateCarrierCommand {
+    type Result = CreateCarrierResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        let carrier_id = Uuid::new_v4();
+        info!("Carrier created: {}", carrier_id);
+        event_sender
+            .send(Event::with_data(format!("carrier_created:{}", carrier_id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(CreateCarrierResult { id: carrier_id })
+    }
+}

--- a/src/commands/carriers/delete_carrier_command.rs
+++ b/src/commands/carriers/delete_carrier_command.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteCarrierCommand {
+    pub id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteCarrierResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for DeleteCarrierCommand {
+    type Result = DeleteCarrierResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        info!("Carrier deleted: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("carrier_deleted:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(DeleteCarrierResult { id: self.id })
+    }
+}

--- a/src/commands/carriers/mod.rs
+++ b/src/commands/carriers/mod.rs
@@ -1,0 +1,7 @@
+pub mod create_carrier_command;
+pub mod update_carrier_command;
+pub mod delete_carrier_command;
+
+pub use create_carrier_command::CreateCarrierCommand;
+pub use update_carrier_command::UpdateCarrierCommand;
+pub use delete_carrier_command::DeleteCarrierCommand;

--- a/src/commands/carriers/update_carrier_command.rs
+++ b/src/commands/carriers/update_carrier_command.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct UpdateCarrierCommand {
+    pub id: Uuid,
+    pub name: Option<String>,
+    pub tracking_url: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateCarrierResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for UpdateCarrierCommand {
+    type Result = UpdateCarrierResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!("Carrier updated: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("carrier_updated:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(UpdateCarrierResult { id: self.id })
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -47,8 +47,8 @@ pub mod receiving;
 // Uncomment as they're implemented
 // pub mod quality;
 pub mod suppliers;
-// pub mod warehouses;
-// pub mod carriers;
+pub mod warehouses;
+pub mod carriers;
 // pub mod packaging;
 // pub mod transfers;
 // pub mod kitting;

--- a/src/commands/warehouses/create_warehouse_command.rs
+++ b/src/commands/warehouses/create_warehouse_command.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct CreateWarehouseCommand {
+    #[validate(length(min = 1))]
+    pub name: String,
+    pub location: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateWarehouseResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for CreateWarehouseCommand {
+    type Result = CreateWarehouseResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        let warehouse_id = Uuid::new_v4();
+        info!("Warehouse created: {}", warehouse_id);
+        event_sender
+            .send(Event::with_data(format!("warehouse_created:{}", warehouse_id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(CreateWarehouseResult { id: warehouse_id })
+    }
+}

--- a/src/commands/warehouses/delete_warehouse_command.rs
+++ b/src/commands/warehouses/delete_warehouse_command.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct DeleteWarehouseCommand {
+    pub id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteWarehouseResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for DeleteWarehouseCommand {
+    type Result = DeleteWarehouseResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        info!("Warehouse deleted: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("warehouse_deleted:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(DeleteWarehouseResult { id: self.id })
+    }
+}

--- a/src/commands/warehouses/mod.rs
+++ b/src/commands/warehouses/mod.rs
@@ -1,0 +1,7 @@
+pub mod create_warehouse_command;
+pub mod update_warehouse_command;
+pub mod delete_warehouse_command;
+
+pub use create_warehouse_command::CreateWarehouseCommand;
+pub use update_warehouse_command::UpdateWarehouseCommand;
+pub use delete_warehouse_command::DeleteWarehouseCommand;

--- a/src/commands/warehouses/update_warehouse_command.rs
+++ b/src/commands/warehouses/update_warehouse_command.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct UpdateWarehouseCommand {
+    pub id: Uuid,
+    pub name: Option<String>,
+    pub location: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateWarehouseResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for UpdateWarehouseCommand {
+    type Result = UpdateWarehouseResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!("Warehouse updated: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("warehouse_updated:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(UpdateWarehouseResult { id: self.id })
+    }
+}


### PR DESCRIPTION
## Summary
- add command modules for managing warehouses
- add command modules for managing carriers
- expose the new modules in `commands/mod.rs`

## Testing
- `cargo check` *(fails: Could not connect to server)*
- `cargo test` *(fails: Could not connect to server)*