### PR TITLE
Add new return commands

### DIFF
--- a/src/commands/returns/add_note_command.rs
+++ b/src/commands/returns/add_note_command.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+use sea_orm::*;
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    models::{
+        return_note_entity::{self, Entity as ReturnNote},
+    },
+    commands::Command,
+};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info, instrument};
+use uuid::Uuid;
+use validator::Validate;
+use chrono::Utc;
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct AddReturnNoteCommand {
+    pub return_id: Uuid,
+    #[validate(length(min = 1, max = 1000))]
+    pub note: String,
+    pub created_by: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AddReturnNoteResult {
+    pub id: Uuid,
+    pub return_id: Uuid,
+    pub note: String,
+}
+
+#[async_trait::async_trait]
+impl Command for AddReturnNoteCommand {
+    type Result = AddReturnNoteResult;
+
+    #[instrument(skip(self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate().map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        let db = db_pool.as_ref();
+        let saved = self.add_note(db).await?;
+
+        event_sender
+            .send(Event::with_data(format!("return_note_added:{}", self.return_id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(AddReturnNoteResult {
+            id: saved.id,
+            return_id: saved.return_id,
+            note: saved.note,
+        })
+    }
+}
+
+impl AddReturnNoteCommand {
+    async fn add_note(
+        &self,
+        db: &DatabaseConnection,
+    ) -> Result<return_note_entity::Model, ServiceError> {
+        let note_id = Uuid::new_v4();
+        let note = return_note_entity::ActiveModel {
+            id: Set(note_id),
+            return_id: Set(self.return_id),
+            note: Set(self.note.clone()),
+            created_by: Set(self.created_by.clone()),
+            created_at: Set(Utc::now().naive_utc()),
+            ..Default::default()
+        };
+
+        ReturnNote::insert(note.clone())
+            .exec(db)
+            .await
+            .map_err(|e| {
+                let msg = format!("Failed to add return note: {}", e);
+                error!("{}", msg);
+                ServiceError::DatabaseError(msg)
+            })?;
+
+        Ok(return_note_entity::Model {
+            id: note_id,
+            return_id: self.return_id,
+            note: self.note.clone(),
+            created_by: self.created_by.clone(),
+            created_at: Utc::now().naive_utc(),
+        })
+    }
+}

--- a/src/commands/returns/mod.rs
+++ b/src/commands/returns/mod.rs
@@ -7,14 +7,12 @@ pub mod refund_return_command;
 pub mod approve_return_command;
 pub mod reject_return_command;
 pub mod restock_returned_items_command;
-
-// Commented out unimplemented modules
-// pub mod receive_return_command;
+pub mod reopen_return_command;
+pub mod receive_return_command;
+pub mod add_note_command;
+pub mod update_return_command;
 // pub mod inspect_return_command;
-// pub mod reopen_return_command;
-// pub mod add_note_command;
 // pub mod generate_shipping_label_command;
-// pub mod update_return_command;
 
 // Re-export commands for easier access
 pub use create_return_command::InitiateReturnCommand;
@@ -26,13 +24,9 @@ pub use refund_return_command::RefundReturnCommand;
 pub use approve_return_command::ApproveReturnCommand;
 pub use reject_return_command::RejectReturnCommand;
 pub use restock_returned_items_command::RestockReturnedItemsCommand;
-
-// Commented out unimplemented re-exports
-/*
-pub use receive_return_command::ReceiveReturnCommand;
-pub use inspect_return_command::InspectReturnCommand;
 pub use reopen_return_command::ReopenReturnCommand;
+pub use receive_return_command::ReceiveReturnCommand;
 pub use add_note_command::AddNoteCommand;
-pub use generate_shipping_label_command::GenerateShippingLabelCommand;
 pub use update_return_command::UpdateReturnCommand;
-*/
+// pub use inspect_return_command::InspectReturnCommand;
+// pub use generate_shipping_label_command::GenerateShippingLabelCommand;

--- a/src/commands/returns/receive_return_command.rs
+++ b/src/commands/returns/receive_return_command.rs
@@ -1,0 +1,85 @@
+use std::sync::Arc;
+use sea_orm::*;
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    models::{
+        return_entity::{self, Entity as Return},
+        return_entity::ReturnStatus,
+    },
+    commands::Command,
+};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info, instrument};
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ReceiveReturnCommand {
+    pub return_id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ReceiveReturnResult {
+    pub id: Uuid,
+    pub status: String,
+}
+
+#[async_trait::async_trait]
+impl Command for ReceiveReturnCommand {
+    type Result = ReceiveReturnResult;
+
+    #[instrument(skip(self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        let db = db_pool.as_ref();
+
+        let received_return = self.mark_received(db).await?;
+
+        event_sender
+            .send(Event::ReturnProcessed(self.return_id))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(ReceiveReturnResult {
+            id: received_return.id,
+            status: received_return.status,
+        })
+    }
+}
+
+impl ReceiveReturnCommand {
+    async fn mark_received(
+        &self,
+        db: &DatabaseConnection,
+    ) -> Result<return_entity::Model, ServiceError> {
+        let return_request = Return::find_by_id(self.return_id)
+            .one(db)
+            .await
+            .map_err(|e| {
+                let msg = format!("Failed to fetch return request: {}", e);
+                error!("{}", msg);
+                ServiceError::DatabaseError(msg)
+            })?
+            .ok_or_else(|| {
+                let msg = format!("Return request with ID {} not found", self.return_id);
+                error!("{}", msg);
+                ServiceError::NotFound(msg)
+            })?;
+
+        let mut active: return_entity::ActiveModel = return_request.into();
+        active.status = Set(ReturnStatus::Received.to_string());
+
+        let updated = active.update(db).await.map_err(|e| {
+            let msg = format!("Failed to update return status: {}", e);
+            error!("{}", msg);
+            ServiceError::DatabaseError(msg)
+        })?;
+
+        info!("Return marked as received", return_id = %self.return_id);
+        Ok(updated)
+    }
+}

--- a/src/commands/returns/update_return_command.rs
+++ b/src/commands/returns/update_return_command.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+use sea_orm::*;
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    models::{
+        return_entity::{self, Entity as Return},
+    },
+    commands::Command,
+};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info, instrument};
+use uuid::Uuid;
+use validator::Validate;
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct UpdateReturnCommand {
+    pub return_id: Uuid,
+    #[validate(length(min = 1))]
+    pub reason: Option<String>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateReturnResult {
+    pub id: Uuid,
+    pub reason: Option<String>,
+    pub description: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl Command for UpdateReturnCommand {
+    type Result = UpdateReturnResult;
+
+    #[instrument(skip(self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate().map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+        let db = db_pool.as_ref();
+        let updated = self.update_return(db).await?;
+
+        event_sender
+            .send(Event::with_data(format!("return_updated:{}", self.return_id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(UpdateReturnResult {
+            id: updated.id,
+            reason: updated.reason,
+            description: updated.description,
+        })
+    }
+}
+
+impl UpdateReturnCommand {
+    async fn update_return(
+        &self,
+        db: &DatabaseConnection,
+    ) -> Result<return_entity::Model, ServiceError> {
+        let return_request = Return::find_by_id(self.return_id)
+            .one(db)
+            .await
+            .map_err(|e| {
+                let msg = format!("Failed to fetch return request: {}", e);
+                error!("{}", msg);
+                ServiceError::DatabaseError(msg)
+            })?
+            .ok_or_else(|| {
+                let msg = format!("Return with ID {} not found", self.return_id);
+                error!("{}", msg);
+                ServiceError::NotFound(msg)
+            })?;
+
+        let mut active: return_entity::ActiveModel = return_request.into();
+        if let Some(reason) = &self.reason {
+            active.reason = Set(reason.clone());
+        }
+        if let Some(desc) = &self.description {
+            active.description = Set(Some(desc.clone()));
+        }
+
+        let updated = active.update(db).await.map_err(|e| {
+            let msg = format!("Failed to update return: {}", e);
+            error!("{}", msg);
+            ServiceError::DatabaseError(msg)
+        })?;
+
+        info!(return_id = %self.return_id, "Return updated");
+        Ok(updated)
+    }
+}


### PR DESCRIPTION
## Summary
- implement several return management commands (receive, update, add note)
- expose them in the `returns` module

## Testing
- `cargo test` *(fails: could not connect to crates.io)*