### PR TITLE
Add additional purchase order commands

### DIFF
--- a/src/commands/purchaseorders/approve_purchase_order_command.rs
+++ b/src/commands/purchaseorders/approve_purchase_order_command.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct ApprovePurchaseOrderCommand {
+    pub id: Uuid,
+    pub approver_id: Uuid,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApprovePurchaseOrderResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for ApprovePurchaseOrderCommand {
+    type Result = ApprovePurchaseOrderResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!(purchase_order_id = %self.id, approver = %self.approver_id, "Purchase order approved");
+        event_sender
+            .send(Event::PurchaseOrderApproved(self.id))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(ApprovePurchaseOrderResult { id: self.id })
+    }
+}

--- a/src/commands/purchaseorders/cancel_purchase_order_command.rs
+++ b/src/commands/purchaseorders/cancel_purchase_order_command.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct CancelPurchaseOrderCommand {
+    pub id: Uuid,
+    #[validate(length(min = 1))]
+    pub reason: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CancelPurchaseOrderResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for CancelPurchaseOrderCommand {
+    type Result = CancelPurchaseOrderResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!(purchase_order_id = %self.id, "Purchase order cancelled");
+        event_sender
+            .send(Event::PurchaseOrderCancelled(self.id))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(CancelPurchaseOrderResult { id: self.id })
+    }
+}

--- a/src/commands/purchaseorders/mod.rs
+++ b/src/commands/purchaseorders/mod.rs
@@ -1,2 +1,11 @@
-// Re-export commands
 pub mod create_purchase_order_command;
+pub mod update_purchase_order_command;
+pub mod approve_purchase_order_command;
+pub mod cancel_purchase_order_command;
+pub mod receive_purchase_order_command;
+
+pub use create_purchase_order_command::CreatePurchaseOrderCommand;
+pub use update_purchase_order_command::UpdatePurchaseOrderCommand;
+pub use approve_purchase_order_command::ApprovePurchaseOrderCommand;
+pub use cancel_purchase_order_command::CancelPurchaseOrderCommand;
+pub use receive_purchase_order_command::ReceivePurchaseOrderCommand;

--- a/src/commands/purchaseorders/receive_purchase_order_command.rs
+++ b/src/commands/purchaseorders/receive_purchase_order_command.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct ReceivePurchaseOrderCommand {
+    pub id: Uuid,
+    pub received_by: Uuid,
+    pub notes: Option<String>,
+    pub items_received: Vec<(Uuid, i32, Option<String>)>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ReceivePurchaseOrderResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for ReceivePurchaseOrderCommand {
+    type Result = ReceivePurchaseOrderResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!(purchase_order_id = %self.id, "Purchase order received");
+        event_sender
+            .send(Event::PurchaseOrderReceived(self.id))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(ReceivePurchaseOrderResult { id: self.id })
+    }
+}

--- a/src/commands/purchaseorders/update_purchase_order_command.rs
+++ b/src/commands/purchaseorders/update_purchase_order_command.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+use chrono::NaiveDateTime;
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct UpdatePurchaseOrderCommand {
+    pub id: Uuid,
+    pub expected_delivery_date: Option<NaiveDateTime>,
+    pub shipping_address: Option<String>,
+    pub notes: Option<String>,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdatePurchaseOrderResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for UpdatePurchaseOrderCommand {
+    type Result = UpdatePurchaseOrderResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!(purchase_order_id = %self.id, "Purchase order updated");
+        event_sender
+            .send(Event::PurchaseOrderUpdated(self.id))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(UpdatePurchaseOrderResult { id: self.id })
+    }
+}


### PR DESCRIPTION
## Summary
- add implementations for purchase order update/approve/cancel/receive commands
- expose the new commands in `purchaseorders::mod`

## Testing
- `cargo check` *(fails: Could not connect to crates.io)*