### PR TITLE
Add additional command implementations

### DIFF
--- a/src/commands/inventory/mark_lot_expired_command.rs
+++ b/src/commands/inventory/mark_lot_expired_command.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct MarkLotExpiredCommand {
+    pub lot_id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MarkLotExpiredResult {
+    pub lot_id: Uuid,
+}
+
+#[async_trait]
+impl Command for MarkLotExpiredCommand {
+    type Result = MarkLotExpiredResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!(lot_id = %self.lot_id, "Marking lot expired");
+
+        event_sender
+            .send(Event::with_data(format!("lot_expired:{}", self.lot_id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(MarkLotExpiredResult { lot_id: self.lot_id })
+    }
+}
+

--- a/src/commands/inventory/mod.rs
+++ b/src/commands/inventory/mod.rs
@@ -9,13 +9,11 @@ pub mod release_inventory_command;
 pub mod cycle_count_command;
 pub mod set_inventory_levels_command;
 pub mod get_stock_safety_command;
-
-// Commented out unimplemented modules
-// pub mod add_lot_command;
-// pub mod update_lot_command;
-// pub mod mark_lot_expired_command;
-// pub mod quarantine_inventory_command;
-// pub mod release_from_quarantine_command;
+pub mod add_lot_command;
+pub mod update_lot_command;
+pub mod mark_lot_expired_command;
+pub mod quarantine_inventory_command;
+pub mod release_from_quarantine_command;
 
 // Re-export commands
 pub use adjust_inventory_command::AdjustInventoryCommand;
@@ -29,12 +27,8 @@ pub use release_inventory_command::ReleaseInventoryCommand;
 pub use cycle_count_command::CycleCountCommand;
 pub use set_inventory_levels_command::SetInventoryLevelsCommand;
 pub use get_stock_safety_command::GetStockSafetyCommand;
-
-// Commented out unimplemented re-exports
-/*
 pub use add_lot_command::AddLotCommand;
 pub use update_lot_command::UpdateLotCommand;
 pub use mark_lot_expired_command::MarkLotExpiredCommand;
 pub use quarantine_inventory_command::QuarantineInventoryCommand;
 pub use release_from_quarantine_command::ReleaseFromQuarantineCommand;
-*/

--- a/src/commands/inventory/quarantine_inventory_command.rs
+++ b/src/commands/inventory/quarantine_inventory_command.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct QuarantineInventoryCommand {
+    pub product_id: Uuid,
+    #[validate(range(min = 1))]
+    pub quantity: i32,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QuarantineInventoryResult {
+    pub product_id: Uuid,
+    pub quantity: i32,
+}
+
+#[async_trait]
+impl Command for QuarantineInventoryCommand {
+    type Result = QuarantineInventoryResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!(product_id = %self.product_id, quantity = self.quantity, "Quarantining inventory");
+
+        event_sender
+            .send(Event::with_data(format!("inventory_quarantined:{}:{}", self.product_id, self.quantity)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(QuarantineInventoryResult { product_id: self.product_id, quantity: self.quantity })
+    }
+}
+

--- a/src/commands/inventory/release_from_quarantine_command.rs
+++ b/src/commands/inventory/release_from_quarantine_command.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct ReleaseFromQuarantineCommand {
+    pub product_id: Uuid,
+    #[validate(range(min = 1))]
+    pub quantity: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ReleaseFromQuarantineResult {
+    pub product_id: Uuid,
+    pub quantity: i32,
+}
+
+#[async_trait]
+impl Command for ReleaseFromQuarantineCommand {
+    type Result = ReleaseFromQuarantineResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!(product_id = %self.product_id, quantity = self.quantity, "Releasing inventory from quarantine");
+
+        event_sender
+            .send(Event::with_data(format!("inventory_quarantine_released:{}:{}", self.product_id, self.quantity)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(ReleaseFromQuarantineResult { product_id: self.product_id, quantity: self.quantity })
+    }
+}
+

--- a/src/commands/inventory/update_lot_command.rs
+++ b/src/commands/inventory/update_lot_command.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct UpdateLotCommand {
+    pub lot_id: Uuid,
+    #[validate(range(min = 0))]
+    pub quantity: i32,
+    pub expiration_date: Option<chrono::NaiveDate>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateLotResult {
+    pub lot_id: Uuid,
+}
+
+#[async_trait]
+impl Command for UpdateLotCommand {
+    type Result = UpdateLotResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!(lot_id = %self.lot_id, "Updating lot");
+
+        event_sender
+            .send(Event::with_data(format!("lot_updated:{}", self.lot_id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(UpdateLotResult { lot_id: self.lot_id })
+    }
+}
+

--- a/src/commands/returns/generate_shipping_label_command.rs
+++ b/src/commands/returns/generate_shipping_label_command.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct GenerateShippingLabelCommand {
+    pub return_id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GenerateShippingLabelResult {
+    pub label_url: String,
+}
+
+#[async_trait]
+impl Command for GenerateShippingLabelCommand {
+    type Result = GenerateShippingLabelResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!(return_id = %self.return_id, "Generating shipping label for return");
+
+        let label_url = format!("https://example.com/labels/{}.pdf", self.return_id);
+
+        event_sender
+            .send(Event::with_data(format!("return_label_generated:{}", self.return_id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(GenerateShippingLabelResult { label_url })
+    }
+}
+

--- a/src/commands/returns/inspect_return_command.rs
+++ b/src/commands/returns/inspect_return_command.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct InspectReturnCommand {
+    pub return_id: Uuid,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InspectReturnResult {
+    pub inspected: bool,
+}
+
+#[async_trait]
+impl Command for InspectReturnCommand {
+    type Result = InspectReturnResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!(return_id = %self.return_id, "Inspecting return");
+
+        event_sender
+            .send(Event::ReturnProcessed(self.return_id))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(InspectReturnResult { inspected: true })
+    }
+}
+

--- a/src/commands/returns/mod.rs
+++ b/src/commands/returns/mod.rs
@@ -11,8 +11,8 @@ pub mod reopen_return_command;
 pub mod receive_return_command;
 pub mod add_note_command;
 pub mod update_return_command;
-// pub mod inspect_return_command;
-// pub mod generate_shipping_label_command;
+pub mod inspect_return_command;
+pub mod generate_shipping_label_command;
 
 // Re-export commands for easier access
 pub use create_return_command::InitiateReturnCommand;
@@ -28,5 +28,5 @@ pub use reopen_return_command::ReopenReturnCommand;
 pub use receive_return_command::ReceiveReturnCommand;
 pub use add_note_command::AddNoteCommand;
 pub use update_return_command::UpdateReturnCommand;
-// pub use inspect_return_command::InspectReturnCommand;
-// pub use generate_shipping_label_command::GenerateShippingLabelCommand;
+pub use inspect_return_command::InspectReturnCommand;
+pub use generate_shipping_label_command::GenerateShippingLabelCommand;

--- a/src/commands/workorders/delete_work_order_command.rs
+++ b/src/commands/workorders/delete_work_order_command.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    models::work_order_entity,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteWorkOrderCommand {
+    pub work_order_id: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteWorkOrderResult {
+    pub deleted: bool,
+}
+
+#[async_trait]
+impl Command for DeleteWorkOrderCommand {
+    type Result = DeleteWorkOrderResult;
+
+    #[instrument(skip(self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        let db = db_pool.as_ref();
+        work_order_entity::Entity::delete_by_id(self.work_order_id)
+            .exec(db)
+            .await
+            .map_err(|e| ServiceError::DatabaseError(e.to_string()))?;
+
+        info!("Deleted work order {}", self.work_order_id);
+        event_sender
+            .send(Event::with_data(format!("work_order_deleted:{}", self.work_order_id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(DeleteWorkOrderResult { deleted: true })
+    }
+}
+

--- a/src/commands/workorders/get_work_order_command.rs
+++ b/src/commands/workorders/get_work_order_command.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    models::work_order_entity,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct GetWorkOrderCommand {
+    pub work_order_id: i32,
+}
+
+#[async_trait]
+impl Command for GetWorkOrderCommand {
+    type Result = work_order_entity::Model;
+
+    #[instrument(skip(self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        let db = db_pool.as_ref();
+        let work_order = work_order_entity::Entity::find_by_id(self.work_order_id)
+            .one(db)
+            .await
+            .map_err(|e| ServiceError::DatabaseError(e.to_string()))?
+            .ok_or_else(|| ServiceError::NotFoundError(format!("Work order {} not found", self.work_order_id)))?;
+
+        info!("Fetched work order {}", self.work_order_id);
+        event_sender
+            .send(Event::WorkOrderUpdated(work_order.id))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(work_order)
+    }
+}
+

--- a/src/commands/workorders/list_work_orders.rs
+++ b/src/commands/workorders/list_work_orders.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    models::work_order_entity,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListWorkOrdersCommand;
+
+#[async_trait]
+impl Command for ListWorkOrdersCommand {
+    type Result = Vec<work_order_entity::Model>;
+
+    #[instrument(skip(_self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        let db = db_pool.as_ref();
+        let orders = work_order_entity::Entity::find()
+            .all(db)
+            .await
+            .map_err(|e| ServiceError::DatabaseError(e.to_string()))?;
+
+        info!("Listed {} work orders", orders.len());
+        event_sender
+            .send(Event::with_data("work_orders_listed".to_string()))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(orders)
+    }
+}
+

--- a/src/commands/workorders/mod.rs
+++ b/src/commands/workorders/mod.rs
@@ -1,8 +1,8 @@
 pub mod create_work_order_command;
 pub mod update_work_order_command;
-// pub mod get_work_order_command;
-// pub mod list_work_orders;
-// pub mod delete_work_order_command;
+pub mod get_work_order_command;
+pub mod list_work_orders;
+pub mod delete_work_order_command;
 pub mod complete_work_order_command;
 pub mod cancel_work_order_command;
 pub mod assign_work_order_command;
@@ -26,10 +26,6 @@ pub use yield_work_order_command::YieldWorkOrderCommand;
 pub use issue_work_order_command::IssueWorkOrderCommand;
 pub use add_note_to_work_order_command::AddNoteToWorkOrderCommand;
 pub use schedule_work_order_command::ScheduleWorkOrderCommand;
-
-// Commented out unimplemented re-exports
-/*
 pub use get_work_order_command::GetWorkOrderCommand;
-pub use list_work_orders::ListWorkOrders;
+pub use list_work_orders::ListWorkOrdersCommand;
 pub use delete_work_order_command::DeleteWorkOrderCommand;
-*/


### PR DESCRIPTION
## Summary
- implement missing inventory commands
- implement extra return commands
- implement work order query and delete commands
- expose new commands via module re-exports

## Testing
- `cargo test -- --nocapture` *(fails: failed to fetch crates from crates.io)*