### PR TITLE
Add analytics report commands

### DIFF
--- a/src/commands/analytics/generate_customer_activity_report_command.rs
+++ b/src/commands/analytics/generate_customer_activity_report_command.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct GenerateCustomerActivityReportCommand {
+    pub customer_id: Uuid,
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GenerateCustomerActivityReportResult {
+    pub customer_id: Uuid,
+    pub orders: usize,
+}
+
+#[async_trait]
+impl Command for GenerateCustomerActivityReportCommand {
+    type Result = GenerateCustomerActivityReportResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        // Placeholder orders count
+        let orders = 0usize;
+        info!(customer_id = %self.customer_id, "Generating customer activity report");
+
+        event_sender
+            .send(Event::with_data("customer_activity_report_generated".to_string()))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(GenerateCustomerActivityReportResult { customer_id: self.customer_id, orders })
+    }
+}
+

--- a/src/commands/analytics/generate_inventory_turnover_command.rs
+++ b/src/commands/analytics/generate_inventory_turnover_command.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct GenerateInventoryTurnoverCommand {
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GenerateInventoryTurnoverResult {
+    pub turnover_rate: f64,
+}
+
+#[async_trait]
+impl Command for GenerateInventoryTurnoverCommand {
+    type Result = GenerateInventoryTurnoverResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        // Placeholder logic for calculating turnover rate
+        let turnover_rate = 0.0_f64;
+        info!("Generating inventory turnover report");
+
+        event_sender
+            .send(Event::with_data("inventory_turnover_generated".to_string()))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(GenerateInventoryTurnoverResult { turnover_rate })
+    }
+}
+

--- a/src/commands/analytics/mod.rs
+++ b/src/commands/analytics/mod.rs
@@ -1,3 +1,7 @@
 pub mod generate_sales_report_command;
+pub mod generate_inventory_turnover_command;
+pub mod generate_customer_activity_report_command;
 
 pub use generate_sales_report_command::GenerateSalesReportCommand;
+pub use generate_inventory_turnover_command::GenerateInventoryTurnoverCommand;
+pub use generate_customer_activity_report_command::GenerateCustomerActivityReportCommand;


### PR DESCRIPTION
## Summary
- extend analytics commands with new inventory turnover & customer activity reports

## Testing
- `cargo test` *(fails: failed to download index)*