### PR TITLE
Expand analytics commands

### DIFF
--- a/src/commands/analytics/generate_customer_activity_report_command.rs
+++ b/src/commands/analytics/generate_customer_activity_report_command.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use validator::Validate;
 use async_trait::async_trait;
-use tracing::{info, instrument};
+use tracing::{error, info, instrument};
+use sea_orm::*;
+use crate::models::order_entity::{self, Entity as Order};
 
 use crate::{
     db::DbPool,
@@ -30,25 +32,36 @@ pub struct GenerateCustomerActivityReportResult {
 impl Command for GenerateCustomerActivityReportCommand {
     type Result = GenerateCustomerActivityReportResult;
 
-    #[instrument(skip(self, _db_pool, event_sender))]
+    #[instrument(skip(self, db_pool, event_sender))]
     async fn execute(
         &self,
-        _db_pool: Arc<DbPool>,
+        db_pool: Arc<DbPool>,
         event_sender: Arc<EventSender>,
     ) -> Result<Self::Result, ServiceError> {
         self.validate()
             .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
 
-        // Placeholder orders count
-        let orders = 0usize;
-        info!(customer_id = %self.customer_id, "Generating customer activity report");
+        let db = db_pool.as_ref();
+
+        let orders = Order::find()
+            .filter(order_entity::Column::CustomerId.eq(self.customer_id))
+            .filter(order_entity::Column::CreatedAt.gte(self.start.naive_utc()))
+            .filter(order_entity::Column::CreatedAt.lte(self.end.naive_utc()))
+            .count(db)
+            .await
+            .map_err(|e| {
+                error!("Failed to count orders for customer {}: {}", self.customer_id, e);
+                ServiceError::DatabaseError(e.to_string())
+            })?;
+
+        info!(customer_id = %self.customer_id, orders, "Generating customer activity report");
 
         event_sender
             .send(Event::with_data("customer_activity_report_generated".to_string()))
             .await
             .map_err(ServiceError::EventError)?;
 
-        Ok(GenerateCustomerActivityReportResult { customer_id: self.customer_id, orders })
+        Ok(GenerateCustomerActivityReportResult { customer_id: self.customer_id, orders: orders as usize })
     }
 }
 

--- a/src/commands/analytics/generate_inventory_turnover_command.rs
+++ b/src/commands/analytics/generate_inventory_turnover_command.rs
@@ -3,7 +3,12 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 use async_trait::async_trait;
-use tracing::{info, instrument};
+use tracing::{error, info, instrument};
+use sea_orm::*;
+use crate::models::{
+    inventory_level_entity::{self, Entity as InventoryLevel},
+    inventory_transaction_entity::{self, Entity as InventoryTransaction, InventoryTransactionType},
+};
 
 use crate::{
     db::DbPool,
@@ -27,18 +32,51 @@ pub struct GenerateInventoryTurnoverResult {
 impl Command for GenerateInventoryTurnoverCommand {
     type Result = GenerateInventoryTurnoverResult;
 
-    #[instrument(skip(self, _db_pool, event_sender))]
+    #[instrument(skip(self, db_pool, event_sender))]
     async fn execute(
         &self,
-        _db_pool: Arc<DbPool>,
+        db_pool: Arc<DbPool>,
         event_sender: Arc<EventSender>,
     ) -> Result<Self::Result, ServiceError> {
         self.validate()
             .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
 
-        // Placeholder logic for calculating turnover rate
-        let turnover_rate = 0.0_f64;
-        info!("Generating inventory turnover report");
+        let db = db_pool.as_ref();
+
+        // Total sales during the period
+        let sales_qty: i32 = InventoryTransaction::find()
+            .filter(
+                Condition::all()
+                    .add(inventory_transaction_entity::Column::TransactionType.eq(InventoryTransactionType::Sale))
+                    .add(inventory_transaction_entity::Column::CreatedAt.gte(self.start.naive_utc()))
+                    .add(inventory_transaction_entity::Column::CreatedAt.lte(self.end.naive_utc())),
+            )
+            .sum::<i32>(inventory_transaction_entity::Column::Quantity)
+            .await
+            .map_err(|e| {
+                error!("Failed to sum sales quantity: {}", e);
+                ServiceError::DatabaseError(e.to_string())
+            })?
+            .unwrap_or(0);
+
+        // Average on hand inventory across all products
+        let levels = InventoryLevel::find().all(db).await.map_err(|e| {
+            error!("Failed to fetch inventory levels: {}", e);
+            ServiceError::DatabaseError(e.to_string())
+        })?;
+        let avg_inventory = if levels.is_empty() {
+            0.0
+        } else {
+            levels.iter().map(|l| l.on_hand_quantity as f64).sum::<f64>() / levels.len() as f64
+        };
+
+        let turnover_rate = if avg_inventory > 0.0 {
+            sales_qty as f64 / avg_inventory
+        } else {
+            0.0
+        };
+
+        info!(start = %self.start, end = %self.end, turnover_rate, "Generating inventory turnover report");
 
         event_sender
             .send(Event::with_data("inventory_turnover_generated".to_string()))

--- a/src/commands/analytics/generate_sales_report_command.rs
+++ b/src/commands/analytics/generate_sales_report_command.rs
@@ -3,7 +3,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 use async_trait::async_trait;
-use tracing::{info, instrument};
+use tracing::{error, info, instrument};
+use sea_orm::*;
+use crate::models::order_entity::{self, Entity as Order};
 
 use crate::{
     db::DbPool,
@@ -27,18 +29,32 @@ pub struct GenerateSalesReportResult {
 impl Command for GenerateSalesReportCommand {
     type Result = GenerateSalesReportResult;
 
-    #[instrument(skip(self, _db_pool, event_sender))]
+    #[instrument(skip(self, db_pool, event_sender))]
     async fn execute(
         &self,
-        _db_pool: Arc<DbPool>,
+        db_pool: Arc<DbPool>,
         event_sender: Arc<EventSender>,
     ) -> Result<Self::Result, ServiceError> {
         self.validate()
             .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
 
-        // Placeholder total sales value
-        let total = 0.0;
-        info!("Generating sales report");
+        let db = db_pool.as_ref();
+
+        let total = Order::find()
+            .filter(
+                Condition::all()
+                    .add(order_entity::Column::CreatedAt.gte(self.start.naive_utc()))
+                    .add(order_entity::Column::CreatedAt.lte(self.end.naive_utc())),
+            )
+            .sum::<f64>(order_entity::Column::TotalAmount)
+            .await
+            .map_err(|e| {
+                error!("Failed to calculate total sales: {}", e);
+                ServiceError::DatabaseError(e.to_string())
+            })?
+            .unwrap_or(0.0);
+
+        info!(start = %self.start, end = %self.end, total_sales = total, "Generating sales report");
 
         event_sender
             .send(Event::with_data("sales_report_generated".to_string()))


### PR DESCRIPTION
## Summary
- flesh out analytics commands with real DB queries
- compute total sales, customer order counts and inventory turnover

## Testing
- `cargo test --quiet` *(fails: failed to download from `https://index.crates.io/config.json`)*