### PR TITLE
Add customer command modules

### DIFF
--- a/src/commands/customers/create_customer_command.rs
+++ b/src/commands/customers/create_customer_command.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct CreateCustomerCommand {
+    #[validate(length(min = 1))]
+    pub name: String,
+    #[validate(email)]
+    pub email: String,
+    pub phone: Option<String>,
+    pub address: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateCustomerResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for CreateCustomerCommand {
+    type Result = CreateCustomerResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        let customer_id = Uuid::new_v4();
+        info!("Customer created: {}", customer_id);
+        event_sender
+            .send(Event::with_data(format!("customer_created:{}", customer_id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(CreateCustomerResult { id: customer_id })
+    }
+}

--- a/src/commands/customers/delete_customer_command.rs
+++ b/src/commands/customers/delete_customer_command.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteCustomerCommand {
+    pub id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteCustomerResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for DeleteCustomerCommand {
+    type Result = DeleteCustomerResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        info!("Customer deleted: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("customer_deleted:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(DeleteCustomerResult { id: self.id })
+    }
+}

--- a/src/commands/customers/mod.rs
+++ b/src/commands/customers/mod.rs
@@ -1,0 +1,7 @@
+pub mod create_customer_command;
+pub mod update_customer_command;
+pub mod delete_customer_command;
+
+pub use create_customer_command::CreateCustomerCommand;
+pub use update_customer_command::UpdateCustomerCommand;
+pub use delete_customer_command::DeleteCustomerCommand;

--- a/src/commands/customers/update_customer_command.rs
+++ b/src/commands/customers/update_customer_command.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct UpdateCustomerCommand {
+    pub id: Uuid,
+    #[validate(length(min = 1))]
+    pub name: Option<String>,
+    #[validate(email)]
+    pub email: Option<String>,
+    pub phone: Option<String>,
+    pub address: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateCustomerResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for UpdateCustomerCommand {
+    type Result = UpdateCustomerResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!("Customer updated: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("customer_updated:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(UpdateCustomerResult { id: self.id })
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -56,3 +56,4 @@ pub mod forecasting;
 pub mod audit;
 pub mod analytics;
 pub mod payments;
+pub mod customers;


### PR DESCRIPTION
## Summary
- add new `customers` command module with create/update/delete operations
- export new module from `commands/mod.rs`

## Testing
- `cargo check` *(fails: failed to download crates)*
- `cargo fmt --all -- --check` *(fails: rustfmt not installed)*