### PR TITLE
Add customer service query commands

### DIFF
--- a/src/commands/customers/count_customers_command.rs
+++ b/src/commands/customers/count_customers_command.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+use sea_orm::*;
+use serde::{Deserialize, Serialize};
+use async_trait::async_trait;
+use tracing::{error, info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    models::customer::{self, Entity as Customer},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CountCustomersCommand;
+
+#[async_trait]
+impl Command for CountCustomersCommand {
+    type Result = u64;
+
+    #[instrument(skip(self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        let db = db_pool.as_ref();
+        let count = Customer::find()
+            .count(db)
+            .await
+            .map_err(|e| {
+                let msg = format!("Failed to count customers: {}", e);
+                error!("{}", msg);
+                ServiceError::DatabaseError(msg)
+            })?;
+
+        info!(count, "Counted customers");
+        event_sender
+            .send(Event::with_data("customers_counted".to_string()))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(count)
+    }
+}

--- a/src/commands/customers/get_customer_by_email_command.rs
+++ b/src/commands/customers/get_customer_by_email_command.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+use sea_orm::*;
+use serde::{Deserialize, Serialize};
+use async_trait::async_trait;
+use tracing::{error, info, instrument};
+use validator::Validate;
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    models::customer::{self, Entity as Customer},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct GetCustomerByEmailCommand {
+    #[validate(email)]
+    pub email: String,
+}
+
+#[async_trait]
+impl Command for GetCustomerByEmailCommand {
+    type Result = Option<customer::Model>;
+
+    #[instrument(skip(self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        let db = db_pool.as_ref();
+        let customer = Customer::find()
+            .filter(customer::Column::Email.eq(self.email.clone()))
+            .one(db)
+            .await
+            .map_err(|e| {
+                let msg = format!("Failed to get customer by email: {}", e);
+                error!("{}", msg);
+                ServiceError::DatabaseError(msg)
+            })?;
+
+        info!("Fetched customer by email: {}", self.email);
+        event_sender
+            .send(Event::with_data(format!("customer_fetched_by_email:{}", self.email)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(customer)
+    }
+}

--- a/src/commands/customers/get_customer_command.rs
+++ b/src/commands/customers/get_customer_command.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+use sea_orm::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use async_trait::async_trait;
+use tracing::{error, info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    models::customer::{self, Entity as Customer},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetCustomerCommand {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for GetCustomerCommand {
+    type Result = Option<customer::Model>;
+
+    #[instrument(skip(self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        let db = db_pool.as_ref();
+        let customer = Customer::find_by_id(self.id)
+            .one(db)
+            .await
+            .map_err(|e| {
+                let msg = format!("Failed to get customer: {}", e);
+                error!("{}", msg);
+                ServiceError::DatabaseError(msg)
+            })?;
+
+        info!("Fetched customer: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("customer_fetched:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(customer)
+    }
+}

--- a/src/commands/customers/list_customers_command.rs
+++ b/src/commands/customers/list_customers_command.rs
@@ -1,0 +1,63 @@
+use std::sync::Arc;
+use sea_orm::*;
+use serde::{Deserialize, Serialize};
+use async_trait::async_trait;
+use tracing::{error, info, instrument};
+use validator::Validate;
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    models::customer::{self, Entity as Customer},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct ListCustomersCommand {
+    #[validate(range(min = 1, max = 1000))]
+    pub limit: Option<u64>,
+    pub offset: Option<u64>,
+}
+
+#[async_trait]
+impl Command for ListCustomersCommand {
+    type Result = Vec<customer::Model>;
+
+    #[instrument(skip(self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        let db = db_pool.as_ref();
+        let mut query = Customer::find();
+
+        if let Some(limit) = self.limit {
+            query = query.limit(limit);
+        }
+        if let Some(offset) = self.offset {
+            query = query.offset(offset);
+        }
+
+        let customers = query
+            .all(db)
+            .await
+            .map_err(|e| {
+                let msg = format!("Failed to list customers: {}", e);
+                error!("{}", msg);
+                ServiceError::DatabaseError(msg)
+            })?;
+
+        info!(count = customers.len(), "Listed customers");
+        event_sender
+            .send(Event::with_data("customers_listed".to_string()))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(customers)
+    }
+}

--- a/src/commands/customers/mod.rs
+++ b/src/commands/customers/mod.rs
@@ -1,7 +1,17 @@
 pub mod create_customer_command;
 pub mod update_customer_command;
 pub mod delete_customer_command;
+pub mod get_customer_command;
+pub mod get_customer_by_email_command;
+pub mod list_customers_command;
+pub mod search_customers_command;
+pub mod count_customers_command;
 
 pub use create_customer_command::CreateCustomerCommand;
 pub use update_customer_command::UpdateCustomerCommand;
 pub use delete_customer_command::DeleteCustomerCommand;
+pub use get_customer_command::GetCustomerCommand;
+pub use get_customer_by_email_command::GetCustomerByEmailCommand;
+pub use list_customers_command::ListCustomersCommand;
+pub use search_customers_command::SearchCustomersCommand;
+pub use count_customers_command::CountCustomersCommand;

--- a/src/commands/customers/search_customers_command.rs
+++ b/src/commands/customers/search_customers_command.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+use sea_orm::*;
+use serde::{Deserialize, Serialize};
+use async_trait::async_trait;
+use tracing::{error, info, instrument};
+use validator::Validate;
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    models::customer::{self, Entity as Customer},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct SearchCustomersCommand {
+    #[validate(length(min = 1))]
+    pub term: String,
+}
+
+#[async_trait]
+impl Command for SearchCustomersCommand {
+    type Result = Vec<customer::Model>;
+
+    #[instrument(skip(self, db_pool, event_sender))]
+    async fn execute(
+        &self,
+        db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        let db = db_pool.as_ref();
+        let pattern = format!("%{}%", self.term);
+
+        let customers = Customer::find()
+            .filter(
+                Condition::any()
+                    .add(customer::Column::Name.like(&pattern))
+                    .add(customer::Column::Email.like(&pattern)),
+            )
+            .all(db)
+            .await
+            .map_err(|e| {
+                let msg = format!("Failed to search customers: {}", e);
+                error!("{}", msg);
+                ServiceError::DatabaseError(msg)
+            })?;
+
+        info!(count = customers.len(), term = self.term, "Searched customers");
+        event_sender
+            .send(Event::with_data("customers_searched".to_string()))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(customers)
+    }
+}


### PR DESCRIPTION
## Summary
- extend the customer command module
- add commands for getting, listing, searching and counting customers
- support querying customers by email

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*