### PR TITLE
Extend customer service commands

### DIFF
--- a/src/commands/customers/activate_customer_command.rs
+++ b/src/commands/customers/activate_customer_command.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ActivateCustomerCommand {
+    pub id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ActivateCustomerResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for ActivateCustomerCommand {
+    type Result = ActivateCustomerResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        info!("Customer activated: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("customer_activated:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(ActivateCustomerResult { id: self.id })
+    }
+}
+

--- a/src/commands/customers/add_customer_note_command.rs
+++ b/src/commands/customers/add_customer_note_command.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+use validator::Validate;
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct AddCustomerNoteCommand {
+    pub customer_id: Uuid,
+    #[validate(length(min = 1))]
+    pub note: String,
+    pub created_by: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AddCustomerNoteResult {
+    pub customer_id: Uuid,
+    pub note: String,
+}
+
+#[async_trait]
+impl Command for AddCustomerNoteCommand {
+    type Result = AddCustomerNoteResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!("Customer note added: {}", self.customer_id);
+        event_sender
+            .send(Event::with_data(format!("customer_note_added:{}", self.customer_id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(AddCustomerNoteResult {
+            customer_id: self.customer_id,
+            note: self.note.clone(),
+        })
+    }
+}
+

--- a/src/commands/customers/deactivate_customer_command.rs
+++ b/src/commands/customers/deactivate_customer_command.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeactivateCustomerCommand {
+    pub id: Uuid,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeactivateCustomerResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for DeactivateCustomerCommand {
+    type Result = DeactivateCustomerResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        info!("Customer deactivated: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!(
+                "customer_deactivated:{}:{}",
+                self.id,
+                self.reason.clone().unwrap_or_default()
+            )))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(DeactivateCustomerResult { id: self.id })
+    }
+}
+

--- a/src/commands/customers/flag_customer_command.rs
+++ b/src/commands/customers/flag_customer_command.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+use validator::Validate;
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct FlagCustomerCommand {
+    pub id: Uuid,
+    #[validate(length(min = 1))]
+    pub flag: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlagCustomerResult {
+    pub id: Uuid,
+    pub flag: String,
+}
+
+#[async_trait]
+impl Command for FlagCustomerCommand {
+    type Result = FlagCustomerResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        self.validate()
+            .map_err(|e| ServiceError::ValidationError(e.to_string()))?;
+
+        info!("Customer flagged: {} flag:{}", self.id, self.flag);
+        event_sender
+            .send(Event::with_data(format!("customer_flagged:{}:{}", self.id, self.flag)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(FlagCustomerResult { id: self.id, flag: self.flag.clone() })
+    }
+}
+

--- a/src/commands/customers/mod.rs
+++ b/src/commands/customers/mod.rs
@@ -6,6 +6,10 @@ pub mod get_customer_by_email_command;
 pub mod list_customers_command;
 pub mod search_customers_command;
 pub mod count_customers_command;
+pub mod activate_customer_command;
+pub mod deactivate_customer_command;
+pub mod add_customer_note_command;
+pub mod flag_customer_command;
 
 pub use create_customer_command::CreateCustomerCommand;
 pub use update_customer_command::UpdateCustomerCommand;
@@ -15,3 +19,7 @@ pub use get_customer_by_email_command::GetCustomerByEmailCommand;
 pub use list_customers_command::ListCustomersCommand;
 pub use search_customers_command::SearchCustomersCommand;
 pub use count_customers_command::CountCustomersCommand;
+pub use activate_customer_command::ActivateCustomerCommand;
+pub use deactivate_customer_command::DeactivateCustomerCommand;
+pub use add_customer_note_command::AddCustomerNoteCommand;
+pub use flag_customer_command::FlagCustomerCommand;


### PR DESCRIPTION
## Summary
- add commands to activate, deactivate, flag, and add notes for customers
- expose the new commands in the customers module

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo test --quiet` *(fails to fetch crates, network unavailable)*
