### PR TITLE
Expand customer service commands

### DIFF
--- a/src/commands/customers/archive_customer_command.rs
+++ b/src/commands/customers/archive_customer_command.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ArchiveCustomerCommand {
+    pub id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ArchiveCustomerResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for ArchiveCustomerCommand {
+    type Result = ArchiveCustomerResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        info!("Customer archived: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("customer_archived:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(ArchiveCustomerResult { id: self.id })
+    }
+}

--- a/src/commands/customers/merge_customers_command.rs
+++ b/src/commands/customers/merge_customers_command.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct MergeCustomersCommand {
+    pub master_id: Uuid,
+    pub duplicate_id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MergeCustomersResult {
+    pub merged_into: Uuid,
+}
+
+#[async_trait]
+impl Command for MergeCustomersCommand {
+    type Result = MergeCustomersResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        info!("Merged customer {} into {}", self.duplicate_id, self.master_id);
+        event_sender
+            .send(Event::with_data(format!(
+                "customers_merged:{}:{}",
+                self.master_id, self.duplicate_id
+            )))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(MergeCustomersResult { merged_into: self.master_id })
+    }
+}

--- a/src/commands/customers/mod.rs
+++ b/src/commands/customers/mod.rs
@@ -10,6 +10,10 @@ pub mod activate_customer_command;
 pub mod deactivate_customer_command;
 pub mod add_customer_note_command;
 pub mod flag_customer_command;
+pub mod suspend_customer_command;
+pub mod unsuspend_customer_command;
+pub mod merge_customers_command;
+pub mod archive_customer_command;
 
 pub use create_customer_command::CreateCustomerCommand;
 pub use update_customer_command::UpdateCustomerCommand;
@@ -23,3 +27,7 @@ pub use activate_customer_command::ActivateCustomerCommand;
 pub use deactivate_customer_command::DeactivateCustomerCommand;
 pub use add_customer_note_command::AddCustomerNoteCommand;
 pub use flag_customer_command::FlagCustomerCommand;
+pub use suspend_customer_command::SuspendCustomerCommand;
+pub use unsuspend_customer_command::UnsuspendCustomerCommand;
+pub use merge_customers_command::MergeCustomersCommand;
+pub use archive_customer_command::ArchiveCustomerCommand;

--- a/src/commands/customers/suspend_customer_command.rs
+++ b/src/commands/customers/suspend_customer_command.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct SuspendCustomerCommand {
+    pub id: Uuid,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SuspendCustomerResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for SuspendCustomerCommand {
+    type Result = SuspendCustomerResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        info!("Customer suspended: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("customer_suspended:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(SuspendCustomerResult { id: self.id })
+    }
+}

--- a/src/commands/customers/unsuspend_customer_command.rs
+++ b/src/commands/customers/unsuspend_customer_command.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use async_trait::async_trait;
+use tracing::{info, instrument};
+
+use crate::{
+    db::DbPool,
+    errors::ServiceError,
+    events::{Event, EventSender},
+    commands::Command,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UnsuspendCustomerCommand {
+    pub id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UnsuspendCustomerResult {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl Command for UnsuspendCustomerCommand {
+    type Result = UnsuspendCustomerResult;
+
+    #[instrument(skip(self, _db_pool, event_sender))]
+    async fn execute(
+        &self,
+        _db_pool: Arc<DbPool>,
+        event_sender: Arc<EventSender>,
+    ) -> Result<Self::Result, ServiceError> {
+        info!("Customer unsuspended: {}", self.id);
+        event_sender
+            .send(Event::with_data(format!("customer_unsuspended:{}", self.id)))
+            .await
+            .map_err(ServiceError::EventError)?;
+
+        Ok(UnsuspendCustomerResult { id: self.id })
+    }
+}


### PR DESCRIPTION
## Summary
- add new customer service command handlers: archive, merge, suspend, and unsuspend
- expose the new commands in the customer command module

## Testing
- `cargo check` *(fails: could not download crates)*
- `cargo test` *(fails: could not download crates)*