### PR TITLE
Cleanup duplicate route handlers

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -13,7 +13,6 @@ pub mod auth;
 pub mod users;
 pub mod notifications;
 pub mod asn;
-pub mod categories;
 
 // Re-export common utility functions for handlers
 pub mod common {

--- a/src/handlers/returns.rs
+++ b/src/handlers/returns.rs
@@ -25,7 +25,7 @@ use validator::Validate;
 use tracing::info;
 use super::common::{validate_input, map_service_error, success_response, created_response, no_content_response, PaginationParams};
 
-// Add routes configuration
+/// Creates the router for return endpoints
 pub fn returns_routes() -> Router {
     Router::new()
         .route("/", get(list_returns))
@@ -320,15 +320,3 @@ async fn restock_returned_items(
     }))
 }
 
-/// Creates the router for return endpoints
-pub fn return_routes() -> Router {
-    Router::new()
-        .route("/", post(create_return))
-        .route("/:id", get(get_return))
-        .route("/:id/approve", post(approve_return))
-        .route("/:id/reject", post(reject_return))
-        .route("/:id/cancel", post(cancel_return))
-        .route("/:id/complete", post(complete_return))
-        .route("/:id/refund", post(refund_return))
-        .route("/:id/restock", post(restock_returned_items))
-}

--- a/src/handlers/shipments.rs
+++ b/src/handlers/shipments.rs
@@ -25,7 +25,7 @@ use validator::Validate;
 use tracing::info;
 use super::common::{validate_input, map_service_error, success_response, created_response, no_content_response, PaginationParams};
 
-// Add routes configuration
+/// Creates the router for shipment endpoints
 pub fn shipments_routes() -> Router {
     Router::new()
         .route("/", get(list_shipments))
@@ -348,16 +348,3 @@ async fn get_shipments_for_order(
     success_response(shipments)
 }
 
-/// Creates the router for shipment endpoints
-pub fn shipments_routes() -> Router {
-    Router::new()
-        .route("/", post(create_shipment))
-        .route("/:id", get(get_shipment))
-        .route("/:id", put(update_shipment))
-        .route("/:id/cancel", post(cancel_shipment))
-        .route("/:id/track", get(track_shipment))
-        .route("/:id/confirm-delivery", post(confirm_delivery))
-        .route("/:id/assign-carrier", post(assign_carrier))
-        .route("/:id/ship", post(ship))
-        .route("/order/:order_id", get(get_shipments_for_order))
-}

--- a/src/handlers/work_orders.rs
+++ b/src/handlers/work_orders.rs
@@ -27,7 +27,7 @@ use tracing::info;
 use chrono::{NaiveDateTime, NaiveDate};
 use super::common::{validate_input, map_service_error, success_response, created_response, no_content_response, PaginationParams};
 
-// Add routes configuration
+/// Creates the router for work order endpoints
 pub fn work_orders_routes() -> Router {
     Router::new()
         .route("/", get(list_work_orders))
@@ -505,19 +505,3 @@ async fn get_work_orders_by_schedule(
     success_response(work_orders)
 }
 
-/// Creates the router for work order endpoints
-pub fn work_order_routes() -> Router {
-    Router::new()
-        .route("/", post(create_work_order))
-        .route("/:id", get(get_work_order))
-        .route("/:id", put(update_work_order))
-        .route("/:id/cancel", post(cancel_work_order))
-        .route("/:id/start", post(start_work_order))
-        .route("/:id/complete", post(complete_work_order))
-        .route("/:id/assign", post(assign_work_order))
-        .route("/:id/unassign", post(unassign_work_order))
-        .route("/:id/schedule", post(schedule_work_order))
-        .route("/assignee/:user_id", get(get_work_orders_by_assignee))
-        .route("/status/:status", get(get_work_orders_by_status))
-        .route("/schedule", get(get_work_orders_by_schedule))
-}


### PR DESCRIPTION
## Summary
- remove duplicate router functions in several handler modules
- drop unused `categories` module from handler registry
- keep one canonical route function per module

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*