### PR TITLE
Improve order handlers

### DIFF
--- a/src/handlers/orders.rs
+++ b/src/handlers/orders.rs
@@ -6,9 +6,15 @@ use axum::{
 };
 use crate::{
     entities::order::{Model as OrderModel, ActiveModel as OrderActiveModel},
-    errors::{ServiceError, AppError, ApiError},
+    errors::ApiError,
     auth::AuthenticatedUser,
-    handlers::common::PaginationParams,
+    handlers::common::{
+        PaginationParams, validate_input, map_service_error, success_response,
+        created_response, no_content_response,
+    },
+    db::DbPool,
+    events::EventSender,
+    services::orders::OrderService,
     AppState,
 };
 use std::sync::Arc;
@@ -17,13 +23,18 @@ use validator::Validate;
 use chrono::{DateTime, Utc};
 use serde_json::json;
 use tracing::info;
+use uuid::Uuid;
 
 // Import the commands
 use crate::commands::orders::{
     CreateOrderCommand, ApplyOrderDiscountCommand, CancelOrderCommand,
     UpdateOrderItemsCommand, PartialCancelOrderCommand, AddItemToOrderCommand,
-    RemoveItemFromOrderCommand, ShipOrderCommand,
+    RemoveItemFromOrderCommand, ShipOrderCommand, ApplyPromotionToOrderCommand,
+    DeactivatePromotionCommand, ExchangeOrderCommand, RefundOrderCommand,
+    HoldOrderCommand, ReleaseOrderFromHoldCommand, TagOrderCommand,
+    UpdateShippingAddressCommand, UpdateOrderStatusCommand,
 };
+use crate::models::order::OrderStatus;
 
 // Structs remain the same
 
@@ -35,12 +46,58 @@ pub struct CreateOrderRequest {
     pub items: Vec<crate::commands::orders::create_order_command::OrderItem>,
 }
 
+#[derive(Debug, Deserialize, Validate)]
+struct PromotionRequest {
+    pub promotion_id: i32,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+struct ExchangeOrderRequest {
+    #[validate]
+    pub return_items: Vec<crate::commands::orders::exchange_order_command::ReturnItemInput>,
+    #[validate]
+    pub new_items: Vec<crate::commands::orders::exchange_order_command::OrderItemInput>,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+struct RefundOrderRequest {
+    #[validate(range(min = 0.01))]
+    pub refund_amount: f64,
+    #[validate(length(min = 1, max = 500))]
+    pub reason: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+struct HoldOrderRequest {
+    #[validate(length(min = 1, max = 500))]
+    pub reason: String,
+    pub version: i32,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+struct TagOrderRequest {
+    pub tag_id: i32,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+struct UpdateShippingRequest {
+    #[validate(length(min = 5, max = 255))]
+    pub new_address: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+struct CreateOrderItemRequest {
+    pub product_id: uuid::Uuid,
+    #[validate(range(min = 1))]
+    pub quantity: i32,
+}
+
 async fn create_order(
     State(state): State<Arc<crate::AppState>>,
     AuthenticatedUser(user): AuthenticatedUser,
     Json(order_info): Json<CreateOrderRequest>,
 ) -> Result<impl IntoResponse, crate::errors::ApiError> {
-    order_info.validate().map_err(|e| crate::errors::ApiError::BadRequest(e.to_string()))?;
+    validate_input(&order_info)?;
 
     let command = crate::commands::orders::create_order_command::CreateOrderCommand {
         customer_id: order_info.customer_id,
@@ -48,7 +105,7 @@ async fn create_order(
     };
 
     let order_id = state.services.orders.create_order(command).await
-        .map_err(|e| crate::errors::ApiError::from(e))?;
+        .map_err(map_service_error)?;
     
     info!("Order created by user {}: {:?}", user.user_id, order_id);
     Ok((axum::http::StatusCode::CREATED, Json(serde_json::json!({
@@ -63,7 +120,11 @@ async fn get_order(
     // AuthenticatedUser check temporarily commented out for testing
     // AuthenticatedUser(user): AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    let order = state.order_repository.find_by_id(id).await?
+    let order = state
+        .order_repository
+        .find_by_id(id)
+        .await
+        .map_err(map_service_error)?
         .ok_or_else(|| ApiError::NotFound(format!("Order with ID {} not found", id)))?;
     
     tracing::info!("Order retrieved: {}", id);
@@ -76,15 +137,18 @@ async fn update_order_items(
     State(event_sender): State<Arc<EventSender>>,
     Path(order_id): Path<i32>,
     Json(items_info): Json<UpdateOrderItemsCommand>,
-) -> Result<impl IntoResponse, ServiceError> {
-    items_info.validate()?;
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&items_info)?;
 
     let command = UpdateOrderItemsCommand {
         order_id,
         items: items_info.items,
     };
 
-    let result = command.execute(db_pool, event_sender).await?;
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
     info!("Order items updated for order ID {}: {:?}", order_id, result);
     Ok(Json(result))
 }
@@ -93,8 +157,11 @@ async fn delete_order(
     State(order_service): State<Arc<OrderService>>,
     Path(id): Path<i32>,
     AuthenticatedUser(user): AuthenticatedUser,
-) -> Result<impl IntoResponse, ServiceError> {
-    order_service.delete_order(id, user.user_id).await?;
+) -> Result<impl IntoResponse, ApiError> {
+    order_service
+        .delete_order(id, user.user_id)
+        .await
+        .map_err(map_service_error)?;
     info!("Order deleted by user {}: {}", user.user_id, id);
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
@@ -103,8 +170,11 @@ async fn list_orders(
     State(order_service): State<Arc<OrderService>>,
     AuthenticatedUser(user): AuthenticatedUser,
     Query(query): Query<PaginationParams>,
-) -> Result<impl IntoResponse, ServiceError> {
-    let (orders, total) = order_service.list_orders(user.user_id, query).await?;
+) -> Result<impl IntoResponse, ApiError> {
+    let (orders, total) = order_service
+        .list_orders(user.user_id, query)
+        .await
+        .map_err(map_service_error)?;
     info!("Orders listed by user {}: total {}", user.user_id, total);
     Ok(Json(json!({
         "orders": orders,
@@ -118,8 +188,11 @@ async fn search_orders(
     State(order_service): State<Arc<OrderService>>,
     AuthenticatedUser(user): AuthenticatedUser,
     Query(query): Query<OrderSearchParams>,
-) -> Result<impl IntoResponse, ServiceError> {
-    let (orders, total) = order_service.search_orders(user.user_id, query).await?;
+) -> Result<impl IntoResponse, ApiError> {
+    let (orders, total) = order_service
+        .search_orders(user.user_id, query)
+        .await
+        .map_err(map_service_error)?;
     info!("Orders searched by user {}: total {}", user.user_id, total);
     Ok(Json(json!({
         "orders": orders,
@@ -131,11 +204,11 @@ async fn search_orders(
 async fn add_item_to_order(
     State(db_pool): State<Arc<DbPool>>,
     State(event_sender): State<Arc<EventSender>>,
-    Path(order_id): Path<i32>,
+    Path(order_id): Path<uuid::Uuid>,
     AuthenticatedUser(user): AuthenticatedUser,
     Json(item_info): Json<CreateOrderItemRequest>,
-) -> Result<impl IntoResponse, ServiceError> {
-    item_info.validate()?;
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&item_info)?;
 
     let command = AddItemToOrderCommand {
         order_id,
@@ -143,7 +216,10 @@ async fn add_item_to_order(
         quantity: item_info.quantity,
     };
 
-    let order_item = command.execute(db_pool, event_sender).await?;
+    let order_item = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
     info!("Item added to order by user {}: {:?}", user.user_id, order_item);
     Ok((axum::http::StatusCode::CREATED, Json(order_item)))
 }
@@ -153,12 +229,15 @@ async fn remove_item_from_order(
     State(event_sender): State<Arc<EventSender>>,
     Path((order_id, item_id)): Path<(i32, i32)>,
     AuthenticatedUser(user): AuthenticatedUser,
-) -> Result<impl IntoResponse, ServiceError> {
+) -> Result<impl IntoResponse, ApiError> {
     let command = RemoveItemFromOrderCommand { order_id, item_id };
 
-    command.execute(db_pool, event_sender).await?;
+    command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
     info!("Item removed from order by user {}: order_id={}, item_id={}", user.user_id, order_id, item_id);
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    Ok(no_content_response())
 }
 
 async fn partial_cancel_order(
@@ -166,15 +245,18 @@ async fn partial_cancel_order(
     State(event_sender): State<Arc<EventSender>>,
     Path(order_id): Path<i32>,
     Json(cancel_info): Json<PartialCancelOrderCommand>,
-) -> Result<impl IntoResponse, ServiceError> {
-    cancel_info.validate()?;
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&cancel_info)?;
 
     let command = PartialCancelOrderCommand {
         order_id,
         item_ids: cancel_info.item_ids,
     };
 
-    let result = command.execute(db_pool, event_sender).await?;
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
     info!("Partial order cancellation by user {}: {:?}", order_id, result);
     Ok(Json(result))
 }
@@ -185,15 +267,18 @@ async fn cancel_order(
     Path(order_id): Path<i32>,
     AuthenticatedUser(user): AuthenticatedUser,
     Json(cancel_info): Json<CancelOrderCommand>,
-) -> Result<impl IntoResponse, ServiceError> {
-    cancel_info.validate()?;
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&cancel_info)?;
 
     let command = CancelOrderCommand {
         order_id,
         reason: cancel_info.reason,
     };
 
-    let result = command.execute(db_pool, event_sender).await?;
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
     info!("Order {} canceled by user {}: reason={}", order_id, user.user_id, cancel_info.reason);
 
     Ok(Json(result))
@@ -204,13 +289,16 @@ async fn ship_order(
     State(event_sender): State<Arc<EventSender>>,
     Path(id): Path<i32>,
     AuthenticatedUser(user): AuthenticatedUser,
-) -> Result<impl IntoResponse, ServiceError> {
+) -> Result<impl IntoResponse, ApiError> {
     let command = ShipOrderCommand {
         order_id: id,
         user_id: user.user_id,
     };
 
-    let shipped_order = command.execute(db_pool, event_sender).await?;
+    let shipped_order = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
     info!("Order {} shipped by user {}", id, user.user_id);
     Ok(Json(shipped_order))
 }
@@ -220,16 +308,201 @@ async fn apply_discount(
     State(event_sender): State<Arc<EventSender>>,
     Path(order_id): Path<i32>,
     Json(discount_info): Json<ApplyOrderDiscountCommand>,
-) -> Result<impl IntoResponse, ServiceError> {
-    discount_info.validate()?;
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&discount_info)?;
 
     let command = ApplyOrderDiscountCommand {
         order_id,
         discount_amount: discount_info.discount_amount,
     };
 
-    let result = command.execute(db_pool, event_sender).await?;
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
     info!("Discount applied to order {}: amount={}", order_id, discount_info.discount_amount);
+    Ok(Json(result))
+}
+
+async fn apply_promotion(
+    State(db_pool): State<Arc<DbPool>>,
+    State(event_sender): State<Arc<EventSender>>,
+    Path(order_id): Path<i32>,
+    Json(payload): Json<PromotionRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&payload)?;
+
+    let command = ApplyPromotionToOrderCommand {
+        order_id,
+        promotion_id: payload.promotion_id,
+    };
+
+    let order = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
+
+    Ok(Json(order))
+}
+
+async fn remove_promotion(
+    State(db_pool): State<Arc<DbPool>>,
+    State(event_sender): State<Arc<EventSender>>,
+    Path(_order_id): Path<i32>,
+    Json(payload): Json<PromotionRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&payload)?;
+
+    let command = DeactivatePromotionCommand {
+        promotion_id: payload.promotion_id,
+    };
+
+    let promo = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
+
+    Ok(Json(promo))
+}
+
+async fn exchange_order(
+    State(db_pool): State<Arc<DbPool>>,
+    State(event_sender): State<Arc<EventSender>>,
+    Path(order_id): Path<uuid::Uuid>,
+    Json(payload): Json<ExchangeOrderRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&payload)?;
+
+    let command = ExchangeOrderCommand {
+        order_id,
+        return_items: payload.return_items,
+        new_items: payload.new_items,
+    };
+
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
+
+    Ok(Json(result))
+}
+
+async fn refund_order(
+    State(db_pool): State<Arc<DbPool>>,
+    State(event_sender): State<Arc<EventSender>>,
+    Path(order_id): Path<uuid::Uuid>,
+    Json(payload): Json<RefundOrderRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&payload)?;
+
+    let command = RefundOrderCommand {
+        order_id,
+        refund_amount: payload.refund_amount,
+        reason: payload.reason,
+    };
+
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
+
+    Ok(Json(result))
+}
+
+async fn complete_order(
+    State(db_pool): State<Arc<DbPool>>,
+    State(event_sender): State<Arc<EventSender>>,
+    Path(order_id): Path<uuid::Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    let command = UpdateOrderStatusCommand {
+        order_id,
+        new_status: OrderStatus::Delivered,
+    };
+
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
+
+    Ok(Json(result))
+}
+
+async fn hold_order(
+    State(db_pool): State<Arc<DbPool>>,
+    State(event_sender): State<Arc<EventSender>>,
+    Path(order_id): Path<uuid::Uuid>,
+    Json(payload): Json<HoldOrderRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&payload)?;
+
+    let command = HoldOrderCommand {
+        order_id,
+        reason: payload.reason,
+        version: payload.version,
+    };
+
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
+
+    Ok(Json(result))
+}
+
+async fn release_order(
+    State(db_pool): State<Arc<DbPool>>,
+    State(event_sender): State<Arc<EventSender>>,
+    Path(order_id): Path<uuid::Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    let command = ReleaseOrderFromHoldCommand { order_id };
+
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
+
+    Ok(Json(result))
+}
+
+async fn tag_order(
+    State(db_pool): State<Arc<DbPool>>,
+    State(event_sender): State<Arc<EventSender>>,
+    Path(order_id): Path<i32>,
+    Json(payload): Json<TagOrderRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&payload)?;
+
+    let command = TagOrderCommand {
+        order_id,
+        tag_id: payload.tag_id,
+    };
+
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
+
+    Ok(Json(result))
+}
+
+async fn update_shipping(
+    State(db_pool): State<Arc<DbPool>>,
+    State(event_sender): State<Arc<EventSender>>,
+    Path(order_id): Path<i32>,
+    Json(payload): Json<UpdateShippingRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&payload)?;
+
+    let command = UpdateShippingAddressCommand {
+        order_id,
+        new_address: payload.new_address,
+    };
+
+    let result = command
+        .execute(db_pool, event_sender)
+        .await
+        .map_err(map_service_error)?;
+
     Ok(Json(result))
 }
 


### PR DESCRIPTION
## Summary
- expand handler imports and utilities
- add request DTOs for promotions, exchanges, refunds and more
- implement new order handler endpoints (promotion, exchange, refund, etc.)
- refactor existing handlers to use common validation and error mapping

## Testing
- `cargo check -q` *(fails: Could not download dependencies)*