### PR TITLE
Add basic cash sale support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ StateSet API is a comprehensive, scalable, and robust backend system for order m
   - Advanced shipping notice (ASN) creation and management
   - Delivery confirmation workflows
 
-- **Manufacturing & Production**: 
+- **Manufacturing & Production**:
   - Bill of materials (BOM) creation and management
   - Work order scheduling and tracking
   - Component and raw material management
+- **Financial Operations**:
+  - Cash sale creation and tracking
+  - Basic invoicing and payment processing stubs
 
 ## Tech Stack
 

--- a/src/handlers/cash_sales.rs
+++ b/src/handlers/cash_sales.rs
@@ -1,0 +1,41 @@
+use axum::{
+    routing::post,
+    extract::{State, Json},
+    response::IntoResponse,
+    Router,
+};
+use serde::Deserialize;
+use validator::Validate;
+use std::sync::Arc;
+use rust_decimal::Decimal;
+use uuid::Uuid;
+use serde_json::json;
+
+use crate::{
+    AppState,
+    handlers::common::{validate_input, created_response, map_service_error},
+    errors::ApiError,
+};
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct CreateCashSaleRequest {
+    pub order_id: Uuid,
+    pub amount: Decimal,
+    pub payment_method: String,
+}
+
+async fn create_cash_sale(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<CreateCashSaleRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    validate_input(&payload)?;
+    let id = state.services.cash_sales
+        .create_cash_sale(payload.order_id, payload.amount, payload.payment_method)
+        .await
+        .map_err(map_service_error)?;
+    Ok(created_response(json!({"id": id})))
+}
+
+pub fn cash_sale_routes() -> Router {
+    Router::new().route("/", post(create_cash_sale))
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod auth;
 pub mod users;
 pub mod notifications;
 pub mod asn;
+pub mod cash_sales;
 
 // Re-export common utility functions for handlers
 pub mod common {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use crate::services::{
     returns::ReturnService,
     shipments::ShipmentService,
     warranties::WarrantyService,
+    cash_sale::CashSaleService,
 };
 use crate::events::EventSender;
 
@@ -51,6 +52,7 @@ pub struct AppServices {
     pub returns: ReturnService,
     pub shipments: ShipmentService,
     pub warranties: WarrantyService,
+    pub cash_sales: cash_sale::CashSaleService,
 }
 
 impl AppServices {
@@ -62,6 +64,7 @@ impl AppServices {
             returns: init_service!(ReturnService, db_pool, event_sender),
             shipments: init_service!(ShipmentService, db_pool, event_sender),
             warranties: init_service!(WarrantyService, db_pool, event_sender),
+            cash_sales: cash_sale::CashSaleService::new(db_pool.clone()),
         }
     }
 }
@@ -146,6 +149,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .nest("/shipments", handlers::shipments::shipments_routes())
             .nest("/warranties", handlers::warranties::warranties_routes())
             .nest("/work-orders", handlers::work_orders::work_orders_routes())
+            .nest("/cash-sales", handlers::cash_sales::cash_sale_routes())
             // Add other API routes here
         )
         // Configure middleware and state

--- a/src/models/cash_sale.rs
+++ b/src/models/cash_sale.rs
@@ -1,0 +1,36 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize, Validate)]
+#[sea_orm(table_name = "cash_sales")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    pub order_id: Uuid,
+    #[sea_orm(column_type = "Decimal(Some((10, 2)))")]
+    pub amount: Decimal,
+    pub payment_method: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::order_entity::Entity",
+        from = "Column::OrderId",
+        to = "super::order_entity::Column::Id"
+    )]
+    Order,
+}
+
+impl Related<super::order_entity::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Order.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -50,6 +50,7 @@ pub mod incidents;
 pub mod invoices;
 pub mod product_category;
 pub mod reconciles;
+pub mod cash_sale;
 
 // Manufacturing related
 pub mod machine;
@@ -81,6 +82,7 @@ pub mod prelude {
     pub use super::shipment::Entity as Shipment;
     pub use super::warranty::Entity as Warranty;
     pub use super::work_order::Entity as WorkOrder;
+    pub use super::cash_sale::Entity as CashSale;
     
     // ASN entities
     pub use super::asn_entity::Entity as ASN;

--- a/src/services/cash_sale.rs
+++ b/src/services/cash_sale.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+use sea_orm::{DatabaseConnection, ActiveModelTrait, Set};
+use rust_decimal::Decimal;
+use uuid::Uuid;
+use chrono::Utc;
+
+use crate::{
+    errors::AppError,
+    models::cash_sale,
+};
+
+pub struct CashSaleService {
+    db: Arc<DatabaseConnection>,
+}
+
+impl CashSaleService {
+    pub fn new(db: Arc<DatabaseConnection>) -> Self {
+        Self { db }
+    }
+
+    pub async fn create_cash_sale(
+        &self,
+        order_id: Uuid,
+        amount: Decimal,
+        payment_method: String,
+    ) -> Result<Uuid, AppError> {
+        let model = cash_sale::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            order_id: Set(order_id),
+            amount: Set(amount),
+            payment_method: Set(payment_method),
+            created_at: Set(Utc::now()),
+        };
+        let result = model.insert(&*self.db).await?;
+        Ok(result.id)
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -19,6 +19,7 @@ pub mod accounts;
 // Financial Services
 pub mod invoicing;
 pub mod payments;
+pub mod cash_sale;
 pub mod accounting;
 
 // Analytics and Reporting


### PR DESCRIPTION
## Summary
- introduce `cash_sale` model
- implement `CashSaleService`
- expose `cash_sale_routes` and wire into API
- document financial operations in README

## Testing
- `cargo test` *(fails: Could not download dependencies)*