### PR TITLE
Add fulfillment order model

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ StateSet API is a comprehensive, scalable, and robust backend system for order m
 
 ## Features
 
-- **Order Management**: 
+- **Order Management**:
   - Create, retrieve, update, and delete orders
   - Support for complex order workflows (hold, cancel, archive, merge)
   - Order item management and tracking
+  - Fulfillment order creation and status updates
 
 - **Inventory Control**: 
   - Real-time inventory tracking across multiple locations

--- a/src/models/fulfillment_order.rs
+++ b/src/models/fulfillment_order.rs
@@ -1,0 +1,71 @@
+use sea_orm::entity::prelude::*;
+use serde::{Serialize, Deserialize};
+use validator::Validate;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "Text")]
+pub enum FulfillmentOrderStatus {
+    #[sea_orm(string_value = "Pending")]
+    Pending,
+    #[sea_orm(string_value = "Picking")]
+    Picking,
+    #[sea_orm(string_value = "Packed")]
+    Packed,
+    #[sea_orm(string_value = "Shipped")]
+    Shipped,
+    #[sea_orm(string_value = "Delivered")]
+    Delivered,
+    #[sea_orm(string_value = "Cancelled")]
+    Cancelled,
+}
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize, Validate)]
+#[sea_orm(table_name = "fulfillment_orders")]
+pub struct Model {
+    #[sea_orm(primary_key, column_type = "Uuid")]
+    pub id: Uuid,
+    #[sea_orm(column_type = "Uuid")]
+    pub order_id: Uuid,
+    pub status: FulfillmentOrderStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::order::Entity",
+        from = "Column::OrderId",
+        to = "super::order::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Order,
+}
+
+impl Related<super::order::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Order.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+impl Model {
+    pub fn new(order_id: Uuid) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4(),
+            order_id,
+            status: FulfillmentOrderStatus::Pending,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn update_status(&mut self, status: FulfillmentOrderStatus) {
+        self.status = status;
+        self.updated_at = Utc::now();
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -51,6 +51,7 @@ pub mod invoices;
 pub mod product_category;
 pub mod reconciles;
 pub mod cash_sale;
+pub mod fulfillment_order;
 
 // Manufacturing related
 pub mod machine;
@@ -83,6 +84,7 @@ pub mod prelude {
     pub use super::warranty::Entity as Warranty;
     pub use super::work_order::Entity as WorkOrder;
     pub use super::cash_sale::Entity as CashSale;
+    pub use super::fulfillment_order::Entity as FulfillmentOrder;
     
     // ASN entities
     pub use super::asn_entity::Entity as ASN;
@@ -110,4 +112,5 @@ pub mod prelude {
     pub use super::warranty::WarrantyStatus;
     pub use super::work_order::WorkOrderStatus;
     pub use super::work_order::WorkOrderPriority;
+    pub use super::fulfillment_order::FulfillmentOrderStatus;
 }

--- a/src/services/fulfillment_orders.rs
+++ b/src/services/fulfillment_orders.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+use sea_orm::{DatabaseConnection, ActiveModelTrait, Set};
+use uuid::Uuid;
+
+use crate::{errors::AppError, models::fulfillment_order};
+
+pub struct FulfillmentOrderService {
+    db: Arc<DatabaseConnection>,
+}
+
+impl FulfillmentOrderService {
+    pub fn new(db: Arc<DatabaseConnection>) -> Self {
+        Self { db }
+    }
+
+    /// Create a new fulfillment order for an existing order
+    pub async fn create_fulfillment_order(&self, order_id: Uuid) -> Result<Uuid, AppError> {
+        let model = fulfillment_order::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            order_id: Set(order_id),
+            status: Set(fulfillment_order::FulfillmentOrderStatus::Pending),
+            created_at: Set(chrono::Utc::now()),
+            updated_at: Set(chrono::Utc::now()),
+        };
+        let result = model.insert(&*self.db).await?;
+        Ok(result.id)
+    }
+
+    /// Update the status of a fulfillment order
+    pub async fn update_status(
+        &self,
+        fulfillment_order_id: Uuid,
+        status: fulfillment_order::FulfillmentOrderStatus,
+    ) -> Result<(), AppError> {
+        let mut fo: fulfillment_order::ActiveModel = fulfillment_order::Entity::find_by_id(fulfillment_order_id)
+            .one(&*self.db)
+            .await?
+            .ok_or_else(|| AppError::NotFound("fulfillment order not found".into()))?
+            .into();
+        fo.status = Set(status);
+        fo.updated_at = Set(chrono::Utc::now());
+        fo.update(&*self.db).await?;
+        Ok(())
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod orders;
 pub mod inventory;
 pub mod returns;
 pub mod shipments;
+pub mod fulfillment_orders;
 pub mod warranties;
 pub mod work_orders;
 
@@ -45,5 +46,8 @@ pub mod shipment_service {
 }
 pub mod work_order_service {
     pub use super::work_orders::WorkOrderService;
+}
+pub mod fulfillment_order_service {
+    pub use super::fulfillment_orders::FulfillmentOrderService;
 }
 pub mod category_service;


### PR DESCRIPTION
## Summary
- add a FulfillmentOrder entity and related service
- expose the new module from the models and services
- document fulfillment order management in README

## Testing
- `cargo test -q` *(fails: could not download crates)*