### PR TITLE
Add build metadata and version endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ migrations = { path = "migrations" }
 
 [build-dependencies]
 tonic-build = "0.8"
+chrono = { version = "0.4", features = ["serde"] }
 
 [[bin]]
 name = "stateset-api"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ StateSet API provides a rich set of RESTful endpoints:
 - `POST /work-orders/:id/start` - Start a work order
 - `POST /work-orders/:id/complete` - Complete a work order
 
+### Health
+- `GET /health` - Basic health check
+- `GET /health/readiness` - Database readiness check
+- `GET /health/version` - Build and version information
+
 ## Testing
 
 Run the test suite with:

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,9 @@
 use std::env;
 use std::path::PathBuf;
+use std::process::Command;
+
+// We'll use chrono to embed the build timestamp
+use chrono::Utc;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
@@ -35,6 +39,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("cargo:warning=Proto compilation completed");
     println!("cargo:rerun-if-changed=proto");
+
+    // Generate build-time metadata
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash.trim());
+    println!("cargo:rustc-env=BUILD_TIME={}", Utc::now().to_rfc3339());
+
+    // Re-run if the HEAD changes
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads");
 
     Ok(())
 }

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -11,6 +11,15 @@ use tracing::info;
 
 use crate::{db, AppState};
 
+/// Returns build and version information
+pub async fn version_info() -> impl IntoResponse {
+    Json(json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "commit": env!("GIT_HASH"),
+        "built": env!("BUILD_TIME"),
+    }))
+}
+
 /// Basic health check response
 pub async fn health_check() -> impl IntoResponse {
     info!("Health check endpoint called");
@@ -56,4 +65,5 @@ pub fn health_routes() -> Router {
     Router::new()
         .route("/", get(health_check))
         .route("/readiness", get(readiness_check))
+        .route("/version", get(version_info))
 }


### PR DESCRIPTION
## Summary
- generate git commit and build time in build script
- expose new `/health/version` endpoint with build info
- document health endpoints in README

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68407404ade4832eb80266da4ac5a209